### PR TITLE
Add price timestamp for currency ticker type

### DIFF
--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -20,6 +20,7 @@ export type CurrencyTickerInterval = {
 export interface IRawCurrencyTicker {
   currency: string;
   price: string;
+  price_timestamp: string;
   circulating_supply: string;
   max_supply: string;
   market_cap: string;


### PR DESCRIPTION
The currency ticker will return a timestamp for the last known price, so this opens up that value to consumers of the exported ticker types.