### PR TITLE
Change price_timestamp to price_date

### DIFF
--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -20,7 +20,7 @@ export type CurrencyTickerInterval = {
 export interface IRawCurrencyTicker {
   currency: string;
   price: string;
-  price_timestamp: string;
+  price_date: string;
   circulating_supply: string;
   max_supply: string;
   market_cap: string;


### PR DESCRIPTION
Moving to use `price_date` instead of the more specific `price_timestamp` for typings.