### PR TITLE
Add api base setter for changing the base url for nomics api calls

### DIFF
--- a/src/api/currencies_ticker.test.ts
+++ b/src/api/currencies_ticker.test.ts
@@ -5,7 +5,7 @@ import { API_BASE } from "../constants";
 jest.mock("../utils/fetch");
 
 test("currencies ticker requests correct url path", () => {
-  currenciesTicker("xyz", { interval: ["1d"] });
+  currenciesTicker("xyz", API_BASE, { interval: ["1d"] });
 
   expect(fetchJSON).toHaveBeenCalledWith(expect.stringContaining(API_BASE));
   expect(fetchJSON).toHaveBeenCalledWith(
@@ -18,7 +18,7 @@ test("currencies ticker requests correct url path", () => {
 });
 
 test("does not add interval if no interval is passed", () => {
-  currenciesTicker("xyz");
+  currenciesTicker("xyz", API_BASE);
 
   expect(fetchJSON).toHaveBeenCalledWith(
     expect.not.stringContaining("interval")
@@ -26,7 +26,7 @@ test("does not add interval if no interval is passed", () => {
 });
 
 test("passes quote-currency if quoteCurrency is specified", () => {
-  currenciesTicker("xyz", { quoteCurrency: "ETH" });
+  currenciesTicker("xyz", API_BASE, { quoteCurrency: "ETH" });
   expect(fetchJSON).toHaveBeenCalledWith(
     expect.stringContaining("quote-currency")
   );

--- a/src/api/currencies_ticker.test.ts
+++ b/src/api/currencies_ticker.test.ts
@@ -1,11 +1,12 @@
 import currenciesTicker from "./currencies_ticker";
 import { fetchJSON } from "../utils/fetch";
 import { API_BASE } from "../constants";
+import Nomics from "..";
 
 jest.mock("../utils/fetch");
 
 test("currencies ticker requests correct url path", () => {
-  currenciesTicker("xyz", API_BASE, { interval: ["1d"] });
+  currenciesTicker("xyz", { interval: ["1d"] });
 
   expect(fetchJSON).toHaveBeenCalledWith(expect.stringContaining(API_BASE));
   expect(fetchJSON).toHaveBeenCalledWith(
@@ -18,7 +19,7 @@ test("currencies ticker requests correct url path", () => {
 });
 
 test("does not add interval if no interval is passed", () => {
-  currenciesTicker("xyz", API_BASE);
+  currenciesTicker("xyz");
 
   expect(fetchJSON).toHaveBeenCalledWith(
     expect.not.stringContaining("interval")
@@ -26,8 +27,16 @@ test("does not add interval if no interval is passed", () => {
 });
 
 test("passes quote-currency if quoteCurrency is specified", () => {
-  currenciesTicker("xyz", API_BASE, { quoteCurrency: "ETH" });
+  currenciesTicker("xyz", { quoteCurrency: "ETH" });
   expect(fetchJSON).toHaveBeenCalledWith(
     expect.stringContaining("quote-currency")
+  );
+});
+
+test("can change the base url via static property", () => {
+  Nomics.NOMICS_API_BASE = "http://test.nomics.com";
+  currenciesTicker("xyz", { interval: ["1d"] });
+  expect(fetchJSON).toHaveBeenCalledWith(
+    expect.stringContaining("http://test.nomics.com")
   );
 });

--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -41,10 +41,11 @@ export interface IRawCurrencyTicker {
   };
 }
 
-const CURRENCIES_TICKER_URL = `${API_BASE}/v1/currencies/ticker`;
+const CURRENCIES_TICKER_PATH = `/v1/currencies/ticker`;
 
 const currenciesTicker = async (
   key: string,
+  apiBase: string,
   options: ICurrenciesTickerOptions = {}
 ): Promise<IRawCurrencyTicker[]> => {
   const { interval, quoteCurrency } = options;
@@ -54,7 +55,9 @@ const currenciesTicker = async (
     key
   };
 
-  return fetchJSON(`${CURRENCIES_TICKER_URL}?${objToUrlParams(objParams)}`);
+  return fetchJSON(
+    `${apiBase}${CURRENCIES_TICKER_PATH}?${objToUrlParams(objParams)}`
+  );
 };
 
 export default currenciesTicker;

--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -1,6 +1,7 @@
-import { API_BASE, IntervalEnum } from "../constants";
+import { IntervalEnum } from "../constants";
 import { objToUrlParams } from "../utils/url";
 import { fetchJSON } from "../utils/fetch";
+import Nomics from "..";
 
 export interface ICurrenciesTickerOptions {
   interval?: string[];
@@ -45,7 +46,6 @@ const CURRENCIES_TICKER_PATH = `/v1/currencies/ticker`;
 
 const currenciesTicker = async (
   key: string,
-  apiBase: string,
   options: ICurrenciesTickerOptions = {}
 ): Promise<IRawCurrencyTicker[]> => {
   const { interval, quoteCurrency } = options;
@@ -56,7 +56,9 @@ const currenciesTicker = async (
   };
 
   return fetchJSON(
-    `${apiBase}${CURRENCIES_TICKER_PATH}?${objToUrlParams(objParams)}`
+    `${Nomics.NOMICS_API_BASE}${CURRENCIES_TICKER_PATH}?${objToUrlParams(
+      objParams
+    )}`
   );
 };
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,5 @@
 import Nomics from ".";
 import currenciesTicker from "./api/currencies_ticker";
-import { API_BASE } from "./constants";
 
 jest.mock("./api/currencies_ticker");
 
@@ -12,7 +11,7 @@ test("gets an object base when setting up", () => {
 
   n.currenciesTicker(options);
 
-  expect(currenciesTicker).toHaveBeenCalledWith(apiKey, API_BASE, options);
+  expect(currenciesTicker).toHaveBeenCalledWith(apiKey, options);
 });
 
 test("must provide a key", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import Nomics from ".";
 import currenciesTicker from "./api/currencies_ticker";
+import { API_BASE } from "./constants";
 
 jest.mock("./api/currencies_ticker");
 
@@ -11,7 +12,7 @@ test("gets an object base when setting up", () => {
 
   n.currenciesTicker(options);
 
-  expect(currenciesTicker).toHaveBeenCalledWith(apiKey, options);
+  expect(currenciesTicker).toHaveBeenCalledWith(apiKey, API_BASE, options);
 });
 
 test("must provide a key", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,10 +23,15 @@ export interface INomicsOptions {
 class Nomics {
   private apiKey: string;
   private version: number = 1;
-  private apiBase: string = API_BASE;
 
-  set NOMICS_API_BASE(apiBase: string) {
-    this.apiBase = apiBase;
+  private static baseUrl: string = API_BASE;
+
+  public static set NOMICS_API_BASE(apiBase: string) {
+    Nomics.baseUrl = apiBase;
+  }
+
+  public static get NOMICS_API_BASE() {
+    return Nomics.baseUrl;
   }
 
   constructor(options: INomicsOptions) {
@@ -41,7 +46,7 @@ class Nomics {
   }
 
   currenciesTicker(options?: ICurrenciesTickerOptions) {
-    return currenciesTicker(this.apiKey, this.apiBase, options);
+    return currenciesTicker(this.apiKey, options);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import currenciesTicker, {
   IRawCurrencyTicker,
   CurrencyTickerInterval
 } from "./api/currencies_ticker";
-import { IntervalEnum } from "./constants";
+import { IntervalEnum, API_BASE } from "./constants";
 import { isEmpty } from "./utils/str";
 
 export { IRawCurrencyTicker, CurrencyTickerInterval };
@@ -23,6 +23,11 @@ export interface INomicsOptions {
 class Nomics {
   private apiKey: string;
   private version: number = 1;
+  private apiBase: string = API_BASE;
+
+  set NOMICS_API_BASE(apiBase: string) {
+    this.apiBase = apiBase;
+  }
 
   constructor(options: INomicsOptions) {
     const { apiKey, version } = options;
@@ -36,7 +41,7 @@ class Nomics {
   }
 
   currenciesTicker(options?: ICurrenciesTickerOptions) {
-    return currenciesTicker(this.apiKey, options);
+    return currenciesTicker(this.apiKey, this.apiBase, options);
   }
 }
 


### PR DESCRIPTION
This adds a `NOMICS_API_BASE` public property setter to the instance of the Nomics API client. Changing the base url for all api calls for a ticker would go something like this:

```js
const nomics = new Nomics({ apiKey: Key() });
nomics.NOMICS_API_BASE = "https://new-api.nomics.com";
const currencies = await nomics.currenciesTicker({ interval: ["1d"] });
```

I'm up for changing the property name or making is more obscure, but the type mappings are included when this library is built, so it will show up in an IDE for anyone using this with Typescript.