### PR TITLE
currency ticker add original symbol

### DIFF
--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -19,10 +19,11 @@ export type CurrencyTickerInterval = {
 };
 
 export interface IRawCurrencyTicker {
+  id: string;
   currency: string;
+  symbol: string;
   name?: string;
   logo_url?: string;
-  original_symbol?: string;
   price: string;
   price_date: string;
   circulating_supply?: string;

--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -22,6 +22,7 @@ export interface IRawCurrencyTicker {
   currency: string;
   name?: string;
   logo_url?: string;
+  original_symbol?: string;
   price: string;
   price_date: string;
   circulating_supply?: string;


### PR DESCRIPTION
Adds `id` and `symbol` to currency ticker response. `id` replaces `currency`, and `symbol` is the display symbol, which is either the original symbol or the id.