### PR TITLE
Add tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jest": "^24.8.0",
     "prettier": "^1.16.4",
     "ts-jest": "^24.0.2",
+    "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomics",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api/currencies_ticker.test.ts
+++ b/src/api/currencies_ticker.test.ts
@@ -1,7 +1,7 @@
-import currenciesTicker from "./currencies_ticker";
-import { fetchJSON } from "../utils/fetch";
-import { API_BASE } from "../constants";
 import Nomics from "..";
+import { API_BASE } from "../constants";
+import { fetchJSON } from "../utils/fetch";
+import currenciesTicker from "./currencies_ticker";
 
 jest.mock("../utils/fetch");
 

--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -1,7 +1,7 @@
-import { IntervalEnum } from "../constants";
-import { objToUrlParams } from "../utils/url";
-import { fetchJSON } from "../utils/fetch";
 import Nomics from "..";
+import { IntervalEnum } from "../constants";
+import { fetchJSON } from "../utils/fetch";
+import { objToUrlParams } from "../utils/url";
 
 export interface ICurrenciesTickerOptions {
   interval?: string[];
@@ -11,6 +11,7 @@ export interface ICurrenciesTickerOptions {
   includeTransparency?: boolean;
 }
 
+// tslint:disable-next-line: interface-over-type-literal
 export type CurrencyTickerInterval = {
   volume: string;
   price_change: string;
@@ -23,6 +24,7 @@ export type CurrencyTickerInterval = {
   volume_transparency_grade: string;
 };
 
+// tslint:disable-next-line: interface-over-type-literal
 export type VolumeTransparency = {
   grade: string;
   volume: string;
@@ -74,10 +76,10 @@ const currenciesTicker = async (
   const objParams = {
     convert,
     ids: ids && ids.join(","),
-    interval: interval && interval.join(","),
-    "quote-currency": quoteCurrency,
     "include-transparency": includeTransparency,
-    key
+    interval: interval && interval.join(","),
+    key,
+    "quote-currency": quoteCurrency
   };
 
   return fetchJSON(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import currenciesTicker, {
+  CurrencyTickerInterval,
   ICurrenciesTickerOptions,
-  IRawCurrencyTicker,
-  CurrencyTickerInterval
+  IRawCurrencyTicker
 } from "./api/currencies_ticker";
-import { IntervalEnum, API_BASE } from "./constants";
+import { API_BASE, IntervalEnum } from "./constants";
 import { isEmpty } from "./utils/str";
 
 export { IRawCurrencyTicker, CurrencyTickerInterval };
@@ -21,11 +21,6 @@ export interface INomicsOptions {
 }
 
 class Nomics {
-  private apiKey: string;
-  private version: number = 1;
-
-  private static baseUrl: string = API_BASE;
-
   public static set NOMICS_API_BASE(apiBase: string) {
     Nomics.baseUrl = apiBase;
   }
@@ -33,6 +28,10 @@ class Nomics {
   public static get NOMICS_API_BASE() {
     return Nomics.baseUrl;
   }
+
+  private static baseUrl: string = API_BASE;
+  private apiKey: string;
+  private version: number = 1;
 
   constructor(options: INomicsOptions) {
     const { apiKey, version } = options;
@@ -45,7 +44,7 @@ class Nomics {
     this.version = version ? version : this.version;
   }
 
-  currenciesTicker(options?: ICurrenciesTickerOptions) {
+  public currenciesTicker(options?: ICurrenciesTickerOptions) {
     return currenciesTicker(this.apiKey, options);
   }
 }

--- a/src/utils/fetch.test.ts
+++ b/src/utils/fetch.test.ts
@@ -1,5 +1,5 @@
-import { fetchJSON } from "./fetch";
 import fetch from "cross-fetch";
+import { fetchJSON } from "./fetch";
 
 jest.mock("cross-fetch", () =>
   jest.fn(() => ({

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -7,5 +7,5 @@ export const fetchJSON = async (path: string): Promise<any> => {
     throw new Error("Bad response from server");
   }
 
-  return await res.json();
+  return res.json();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -451,6 +451,13 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -640,6 +647,11 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+builtin-modules@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -682,7 +694,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -756,6 +768,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.12.1:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -929,6 +946,11 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
+diff@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
@@ -1000,6 +1022,11 @@ esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 estraverse@^4.2.0:
   version "4.2.0"
@@ -1996,6 +2023,14 @@ jest@^24.8.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -3141,6 +3176,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
 sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
@@ -3376,10 +3416,41 @@ ts-jest@^24.0.2:
     semver "^5.5"
     yargs-parser "10.x"
 
+tslib@^1.8.0, tslib@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
 tslint-config-prettier@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
   integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
+
+tslint@^5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.18.0.tgz#f61a6ddcf372344ac5e41708095bbf043a147ac6"
+  integrity sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.29.0"
+
+tsutils@^2.29.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
I really thought this was added originally, but I guess I only added tslint-config-prettier. This adds tslint along with all of the little linting updates. I overrode the rules for using interfaces instead of types in a couple of places to avoid requiring any changes for clients.