### PR TITLE
Currency ticker volume transparency fields are optional

### DIFF
--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -20,8 +20,8 @@ export type CurrencyTickerInterval = {
   volume_change_pct: string;
   market_cap_change?: string;
   market_cap_change_pct?: string;
-  volume_transparency: VolumeTransparency[];
-  volume_transparency_grade: string;
+  volume_transparency?: VolumeTransparency[];
+  volume_transparency_grade?: string;
 };
 
 // tslint:disable-next-line: interface-over-type-literal


### PR DESCRIPTION
Since you can request the response with or without these fields, they should be optional.