### PR TITLE
Add additional fetch options argument to ticker methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ function client() {
 }
 ```
 
+All ticker functions can take two arguments (both are optional): ticker options (see relevant ticker information) and request fetch options.
+
+```javascript
+nomics.currenciesTicker(tickerOptions, fetchOptions);
+```
+
+For fetch options, an object conforming to [fetch standard options](https://github.com/bitinn/node-fetch#options) can be passed. These options are for more advanced configurations, and for a majority of use cases, should not need to be included.
+
 #### Currently supported Ticker functions
 
 `Currencies`

--- a/src/api/currencies_ticker.test.ts
+++ b/src/api/currencies_ticker.test.ts
@@ -5,56 +5,74 @@ import currenciesTicker from "./currencies_ticker";
 
 jest.mock("../utils/fetch");
 
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
 test("currencies ticker requests correct url path", () => {
   currenciesTicker("xyz", { interval: ["1d"] });
 
-  expect(fetchJSON).toHaveBeenCalledWith(expect.stringContaining(API_BASE));
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("/v1/currencies/ticker?")
+    expect.stringContaining(API_BASE),
+    undefined
   );
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("interval=1d")
+    expect.stringContaining("/v1/currencies/ticker?"),
+    undefined
   );
-  expect(fetchJSON).toHaveBeenCalledWith(expect.stringContaining("key=xyz"));
+  expect(fetchJSON).toHaveBeenCalledWith(
+    expect.stringContaining("interval=1d"),
+    undefined
+  );
+  expect(fetchJSON).toHaveBeenCalledWith(
+    expect.stringContaining("key=xyz"),
+    undefined
+  );
 });
 
 test("does not add interval if no interval is passed", () => {
   currenciesTicker("xyz");
 
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.not.stringContaining("interval")
+    expect.not.stringContaining("interval"),
+    undefined
   );
 });
 
 test("passes quote-currency if quoteCurrency is specified", () => {
   currenciesTicker("xyz", { quoteCurrency: "ETH" });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("quote-currency")
+    expect.stringContaining("quote-currency"),
+    undefined
   );
 });
 
 test("passes convert if convert is specified", () => {
   currenciesTicker("xyz", { convert: "ETH" });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("convert=ETH")
+    expect.stringContaining("convert=ETH"),
+    undefined
   );
 });
 
 test("passes ids if ids are specified", () => {
   currenciesTicker("xyz", { ids: ["ETH", "BTC"] });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining(`ids=${encodeURIComponent("ETH,BTC")}`)
+    expect.stringContaining(`ids=${encodeURIComponent("ETH,BTC")}`),
+    undefined
   );
 });
 
 test("passes includeTransparency if specified", () => {
   currenciesTicker("xyz", { includeTransparency: true });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("include-transparency=true")
+    expect.stringContaining("include-transparency=true"),
+    undefined
   );
   currenciesTicker("xyz", {});
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.not.stringContaining("include-transparency")
+    expect.not.stringContaining("include-transparency"),
+    undefined
   );
 });
 
@@ -62,6 +80,21 @@ test("can change the base url via static property", () => {
   Nomics.NOMICS_API_BASE = "http://test.nomics.com";
   currenciesTicker("xyz", { interval: ["1d"] });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("http://test.nomics.com")
+    expect.stringContaining("http://test.nomics.com"),
+    undefined
   );
+});
+
+test("passes request options to fetch", () => {
+  currenciesTicker(
+    "xyz",
+    { interval: ["1d"] },
+    {
+      signal: null
+    }
+  );
+
+  expect(fetchJSON).toHaveBeenCalledWith(expect.any(String), {
+    signal: null
+  });
 });

--- a/src/api/currencies_ticker.ts
+++ b/src/api/currencies_ticker.ts
@@ -64,7 +64,8 @@ const CURRENCIES_TICKER_PATH = `/v1/currencies/ticker`;
 
 const currenciesTicker = async (
   key: string,
-  options: ICurrenciesTickerOptions = {}
+  options: ICurrenciesTickerOptions = {},
+  fetchOptions?: RequestInit
 ): Promise<IRawCurrencyTicker[]> => {
   const {
     convert,
@@ -85,7 +86,8 @@ const currenciesTicker = async (
   return fetchJSON(
     `${Nomics.NOMICS_API_BASE}${CURRENCIES_TICKER_PATH}?${objToUrlParams(
       objParams
-    )}`
+    )}`,
+    fetchOptions
   );
 };
 

--- a/src/api/exchange_markets_ticker.test.ts
+++ b/src/api/exchange_markets_ticker.test.ts
@@ -4,44 +4,74 @@ import exchangeMarketsTicker from "./exchange_markets_ticker";
 
 jest.mock("../utils/fetch");
 
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
 test("exchange markets ticker requests correct url path", () => {
   exchangeMarketsTicker("xyz", { interval: ["1d"] });
 
-  expect(fetchJSON).toHaveBeenCalledWith(expect.stringContaining(API_BASE));
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("/v1/exchange-markets/ticker?")
+    expect.stringContaining(API_BASE),
+    undefined
   );
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("interval=1d")
+    expect.stringContaining("/v1/exchange-markets/ticker?"),
+    undefined
   );
-  expect(fetchJSON).toHaveBeenCalledWith(expect.stringContaining("key=xyz"));
+  expect(fetchJSON).toHaveBeenCalledWith(
+    expect.stringContaining("interval=1d"),
+    undefined
+  );
+  expect(fetchJSON).toHaveBeenCalledWith(
+    expect.stringContaining("key=xyz"),
+    undefined
+  );
 });
 
 test("does not add interval if no interval is passed", () => {
   exchangeMarketsTicker("xyz");
 
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.not.stringContaining("interval")
+    expect.not.stringContaining("interval"),
+    undefined
   );
 });
 
 test("passes currencies if currencies are specified", () => {
   exchangeMarketsTicker("xyz", { currency: ["ETH", "BTC"] });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining(`currency=${encodeURIComponent("ETH,BTC")}`)
+    expect.stringContaining(`currency=${encodeURIComponent("ETH,BTC")}`),
+    undefined
   );
 });
 
 test("passes exchanges if exchanges are specified", () => {
   exchangeMarketsTicker("xyz", { exchange: ["yobit", "binance"] });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining(`exchange=${encodeURIComponent("yobit,binance")}`)
+    expect.stringContaining(`exchange=${encodeURIComponent("yobit,binance")}`),
+    undefined
   );
 });
 
 test("passes convert if convert is specified", () => {
   exchangeMarketsTicker("xyz", { convert: "ETH" });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("convert=ETH")
+    expect.stringContaining("convert=ETH"),
+    undefined
   );
+});
+
+test("passes request options to fetch", () => {
+  exchangeMarketsTicker(
+    "xyz",
+    { interval: ["1d"] },
+    {
+      signal: null
+    }
+  );
+
+  expect(fetchJSON).toHaveBeenCalledWith(expect.any(String), {
+    signal: null
+  });
 });

--- a/src/api/exchange_markets_ticker.ts
+++ b/src/api/exchange_markets_ticker.ts
@@ -48,7 +48,8 @@ const EXCHANGES_TICKER_PATH = `/v1/exchange-markets/ticker`;
 
 const exchangeMarketsTicker = async (
   key: string,
-  options: IExchangeMarketsTickerOptions = {}
+  options: IExchangeMarketsTickerOptions = {},
+  fetchOptions?: RequestInit
 ): Promise<IRawExchangeMarketTicker[]> => {
   const { convert, currency, exchange, interval } = options;
   const objParams = {
@@ -62,7 +63,8 @@ const exchangeMarketsTicker = async (
   return fetchJSON(
     `${Nomics.NOMICS_API_BASE}${EXCHANGES_TICKER_PATH}?${objToUrlParams(
       objParams
-    )}`
+    )}`,
+    fetchOptions
   );
 };
 

--- a/src/api/exchanges_ticker.test.ts
+++ b/src/api/exchanges_ticker.test.ts
@@ -4,37 +4,66 @@ import exchangesTicker from "./exchanges_ticker";
 
 jest.mock("../utils/fetch");
 
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
 test("currencies ticker requests correct url path", () => {
   exchangesTicker("xyz", { interval: ["1d"] });
 
-  expect(fetchJSON).toHaveBeenCalledWith(expect.stringContaining(API_BASE));
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("/v1/exchanges/ticker?")
+    expect.stringContaining(API_BASE),
+    undefined
   );
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("interval=1d")
+    expect.stringContaining("/v1/exchanges/ticker?"),
+    undefined
   );
-  expect(fetchJSON).toHaveBeenCalledWith(expect.stringContaining("key=xyz"));
+  expect(fetchJSON).toHaveBeenCalledWith(
+    expect.stringContaining("interval=1d"),
+    undefined
+  );
+  expect(fetchJSON).toHaveBeenCalledWith(
+    expect.stringContaining("key=xyz"),
+    undefined
+  );
 });
 
 test("does not add interval if no interval is passed", () => {
   exchangesTicker("xyz");
 
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.not.stringContaining("interval")
+    expect.not.stringContaining("interval"),
+    undefined
   );
 });
 
 test("passes ids if ids are specified", () => {
   exchangesTicker("xyz", { ids: ["ETH", "BTC"] });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining(`ids=${encodeURIComponent("ETH,BTC")}`)
+    expect.stringContaining(`ids=${encodeURIComponent("ETH,BTC")}`),
+    undefined
   );
 });
 
 test("passes convert if convert is specified", () => {
   exchangesTicker("xyz", { convert: "ETH" });
   expect(fetchJSON).toHaveBeenCalledWith(
-    expect.stringContaining("convert=ETH")
+    expect.stringContaining("convert=ETH"),
+    undefined
   );
+});
+
+test("passes request options to fetch", () => {
+  exchangesTicker(
+    "xyz",
+    { interval: ["1d"] },
+    {
+      signal: null
+    }
+  );
+
+  expect(fetchJSON).toHaveBeenCalledWith(expect.any(String), {
+    signal: null
+  });
 });

--- a/src/api/exchanges_ticker.ts
+++ b/src/api/exchanges_ticker.ts
@@ -44,7 +44,8 @@ const EXCHANGES_TICKER_PATH = `/v1/exchanges/ticker`;
 
 const exchangesTicker = async (
   key: string,
-  options: IExchangesTickerOptions = {}
+  options: IExchangesTickerOptions = {},
+  fetchOptions?: RequestInit
 ): Promise<IRawExchangeTicker[]> => {
   const { convert, ids, interval } = options;
   const objParams = {
@@ -57,7 +58,8 @@ const exchangesTicker = async (
   return fetchJSON(
     `${Nomics.NOMICS_API_BASE}${EXCHANGES_TICKER_PATH}?${objToUrlParams(
       objParams
-    )}`
+    )}`,
+    fetchOptions
   );
 };
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,7 +11,7 @@ test("gets an object base when setting up", () => {
 
   n.currenciesTicker(options);
 
-  expect(currenciesTicker).toHaveBeenCalledWith(apiKey, options);
+  expect(currenciesTicker).toHaveBeenCalledWith(apiKey, options, undefined);
 });
 
 test("must provide a key", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,16 +61,25 @@ class Nomics {
     this.version = version ? version : this.version;
   }
 
-  public currenciesTicker(options?: ICurrenciesTickerOptions) {
-    return currenciesTicker(this.apiKey, options);
+  public currenciesTicker(
+    options?: ICurrenciesTickerOptions,
+    fetchOptions?: RequestInit
+  ) {
+    return currenciesTicker(this.apiKey, options, fetchOptions);
   }
 
-  public exchangesTicker(options?: IExchangesTickerOptions) {
-    return exchangesTicker(this.apiKey, options);
+  public exchangesTicker(
+    options?: IExchangesTickerOptions,
+    fetchOptions?: RequestInit
+  ) {
+    return exchangesTicker(this.apiKey, options, fetchOptions);
   }
 
-  public exchangeMarketsTicker(options?: IExchangeMarketsTickerOptions) {
-    return exchangeMarketsTicker(this.apiKey, options);
+  public exchangeMarketsTicker(
+    options?: IExchangeMarketsTickerOptions,
+    fetchOptions?: RequestInit
+  ) {
+    return exchangeMarketsTicker(this.apiKey, options, fetchOptions);
   }
 }
 

--- a/src/utils/fetch.test.ts
+++ b/src/utils/fetch.test.ts
@@ -6,6 +6,7 @@ jest.mock("cross-fetch", () =>
     json: jest.fn(() => ({
       test: "ok"
     })),
+    ok: true,
     status: 200
   }))
 );
@@ -13,16 +14,21 @@ jest.mock("cross-fetch", () =>
 test("passes string to fetch lib", async () => {
   await fetchJSON("https://foo.com");
 
-  expect(fetch).toHaveBeenCalledWith("https://foo.com");
+  expect(fetch).toHaveBeenCalledWith("https://foo.com", undefined);
 });
 
-test("throws when response status is greater than 400", async () => {
+test("throws when response status is not ok", async () => {
   (fetch as jest.Mock).mockResolvedValueOnce({
     json: jest.fn(),
+    ok: false,
     status: 401
   });
 
-  await expect(fetchJSON("https://foo.com")).rejects.toThrow(Error);
+  try {
+    await fetchJSON("https://foo.com");
+  } catch (error) {
+    expect(error).toStrictEqual(expect.objectContaining({ status: 401 }));
+  }
 });
 
 test("returns json from response", async () => {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,10 +1,13 @@
 import fetch from "cross-fetch";
 
-export const fetchJSON = async (path: string): Promise<any> => {
-  const res = await fetch(path);
+export const fetchJSON = async (
+  path: string,
+  options?: RequestInit
+): Promise<any> => {
+  const res = await fetch(path, options);
 
-  if (res.status >= 400) {
-    throw new Error("Bad response from server");
+  if (!res.ok) {
+    throw res;
   }
 
   return res.json();


### PR DESCRIPTION
This adds an optional argument to the ticker methods that allow a fetch options object to be passed. This can give finer-tuned configuration to individual requests with fetch. I've also removed the generic "Bad response from server" throw in favor of throwing the response itself to allow for better handling by the consumer.